### PR TITLE
Improv heading style

### DIFF
--- a/app/elements/base.css
+++ b/app/elements/base.css
@@ -1,8 +1,13 @@
 :host {
   --border-color: #736357;
   --border-light-color: #ccc;
+  --heading-font-family: "Roboto Condensed", "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", メイリオ, Meiryo, sans-serif;
   --link-color: #1c1b19;
   --link-hover-color: #ff7300;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--heading-font-family);
 }
 
 a {

--- a/app/elements/submission-wizard-goal.css
+++ b/app/elements/submission-wizard-goal.css
@@ -17,6 +17,7 @@
 
 .tabs {
   border-bottom: solid thin var(--border-light-color);
+  font-family: var(--heading-font-family);
 }
 
 .tabs.cluster {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lit": "^2.0.2"
   },
   "devDependencies": {
+    "@koa/cors": "^3.1.0",
     "@lit/localize-tools": "^0.5.0",
     "@open-wc/testing": "^3.0.3",
     "@rollup/plugin-node-resolve": "^13.0.6",

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -1,5 +1,6 @@
 import _litcss from 'rollup-plugin-lit-css';
 import _yaml from '@rollup/plugin-yaml';
+import cors from '@koa/cors';
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { fromRollup } from '@web/dev-server-rollup';
 
@@ -8,6 +9,12 @@ const yaml   = fromRollup(_yaml);
 
 export default {
   appIndex: 'demo/index.html',
+
+  middleware: [
+    cors({
+      origin: '*'
+    })
+  ],
 
   plugins: [
     esbuildPlugin({ts: true}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@koa/cors@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-3.1.0.tgz#618bb073438cfdbd3ebd0e648a76e33b84f3a3b2"
+  integrity sha512-7ulRC1da/rBa6kj6P4g2aJfnET3z8Uf3SWu60cjbtxTA5g8lxRdX/Bd2P92EagGwwAhANeNw8T8if99rJliR6Q==
+  dependencies:
+    vary "^1.1.2"
+
 "@lit/localize-tools@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@lit/localize-tools/-/localize-tools-0.5.0.tgz#766d6fe738d4c8f15995cc379ae93205d21fbe00"


### PR DESCRIPTION
Followed the font-family used in ddbj/www.

## Before
![Screenshot from 2021-12-16 02-09-16](https://user-images.githubusercontent.com/7548/146232970-d11189be-6f8f-46af-b449-b310798633ef.png)

## After
![Screenshot from 2021-12-16 02-10-13](https://user-images.githubusercontent.com/7548/146233009-bbf04cab-e58f-4d63-a37a-f85122fac523.png)

